### PR TITLE
Correct the capitalization of GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           Hi, I'm Keith Smiley. I make OS X &amp;
           iOS <a href="https://www.lyft.com/" id="apps">apps</a>.
           Look at my code on
-          <a href="https://github.com/keith" id="github">Github</a>.
+          <a href="https://github.com/keith" id="github">GitHub</a>.
           Follow me on
           <a href="https://twitter.com/SmileyKeith" id="twitter">Twitter</a>.
           Read my


### PR DESCRIPTION
This pull request corrects the spelling of **GitHub** 🤓
https://github.com/
